### PR TITLE
change RepoCardsSection so that the whole card is a button 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.2.0-beta1",
-    "energy-charts": "^0.6.17",
+    "energy-charts": "^0.6.18",
     "react": "^18.2.0",
     "react-bootstrap": "^2.4.0",
     "react-dom": "^18.2.0",

--- a/src/components/RepoCardsSection.js
+++ b/src/components/RepoCardsSection.js
@@ -13,15 +13,12 @@ function RepoCardsSection(props) {
         >
           {repositories.map((repository, idx) => (
             <Col className="p-2" key={idx}>
-              <Card bg={cardBg}>
-                <Card.Header>{repository.name}</Card.Header>
-                <Card.Body>{repository.description}</Card.Body>
-                <Card.Footer>
-                  <Button variant="light" href={`/${repository.name}`}>
-                    Explore
-                  </Button>
-                </Card.Footer>
-              </Card>
+              <Button variant="light" href={`/${repository.name}`}>
+                <Card bg={cardBg}>
+                  <Card.Header>{repository.name}</Card.Header>
+                  <Card.Body>{repository.description}</Card.Body>
+                </Card>
+              </Button>
             </Col>
           ))}
         </Row>


### PR DESCRIPTION
which links to the scenario, instead of having a small "explore"  button within the card

Just an idea for a nicer user experience. Please do feel free to merge or reject, as you judge best.